### PR TITLE
Modify kbn-alert to support new name attribute and fix update for throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ command-line utilities for working with Kibana actions and alerts
 
     kbn-alert ls-types
     kbn-alert ls
-    kbn-alert create <alert-type-id> <interval> <json: params> <json: actions>
+    kbn-alert create <alert-type-id> <name> <interval> <json: params> <json: actions>
     kbn-alert get <alert-id>
-    kbn-alert update <alert-id> <interval> <json: params> <json: actions>
+    kbn-alert update <alert-id> <name> <interval> <json: params> <json: actions> <throttle>
     kbn-alert delete <alert-id>
 
 Note that for `kbn-alert` subcommands `create` and `update`, the `actions`
@@ -144,9 +144,10 @@ $ kbn-alert ls-types
 
 $ # alerts are similar to actions, create being wildly different
 
-$ kbn-alert create test.always-firing 1s '{index:test_alert_from_cli}' "[{group:default id:'8fe59625-fda4-400b-94a6-cf75938c163b' params:{message: 'from alert 1s'}}]"
+$ kbn-alert create test.always-firing test 1s '{index:test_alert_from_cli}' "[{group:default id:'8fe59625-fda4-400b-94a6-cf75938c163b' params:{message: 'from alert 1s'}}]"
 {
     "id": "0bdbb930-b485-11e9-86c5-c9b4ac6d5f40",
+    "name": "test",
     "alertTypeId": "test.always-firing",
     "interval": "1s",
     "actions": [
@@ -169,9 +170,11 @@ $ kbn-alert create test.always-firing 1s '{index:test_alert_from_cli}' "[{group:
 
 $ # update the alert to run every minute instead of every second
 
-$ kbn-alert update 0bdbb930-b485-11e9-86c5-c9b4ac6d5f40 1m '{index:test_alert_from_cli}' "[{group:default id:'8fe59625-fda4-400b-94a6-cf75938c163b' params:{message: 'from alert 1m'}}]"
+$ kbn-alert update 0bdbb930-b485-11e9-86c5-c9b4ac6d5f40 'updated test' 1m '{index:test_alert_from_cli}' "[{group:default id:'8fe59625-fda4-400b-94a6-cf75938c163b' params:{message: 'from alert 1m'}}]" 5m
 {
     "id": "0bdbb930-b485-11e9-86c5-c9b4ac6d5f40",
+    "name": "updated test"
+    "throttle": "5m",
     "interval": "1m",
     "actions": [
         {

--- a/kbn-alert.js
+++ b/kbn-alert.js
@@ -130,9 +130,9 @@ function getHelpText () {
 usage:
   ${PROGRAM} ls-types
   ${PROGRAM} ls 
-  ${PROGRAM} create <alert-type-id> <interval> <json: params> <json: actions>
+  ${PROGRAM} create <alert-type-id> <name> <interval> <json: params> <json: actions>
   ${PROGRAM} get <alert-id>
-  ${PROGRAM} update <alert-id> <interval> <json: params> <json: actions>
+  ${PROGRAM} update <alert-id> <name> <interval> <json: params> <json: actions> <throttle>
   ${PROGRAM} delete <alert-id>
 
 options:

--- a/lib/alert-commands.js
+++ b/lib/alert-commands.js
@@ -42,8 +42,10 @@ async function ls (baseUrl, id, args, opts) {
 async function create (baseUrl, id, args, opts) {
   if (id == null) throw new Error('id parameter required')
 
-  const [interval, alertTypeParamsJSON, actionsJSON] = args
+  const [name, interval, alertTypeParamsJSON, actionsJSON] = args
   if (interval == null) throw new Error('interval parameter required')
+
+  if (name == null) throw new Error('name parameter required')
 
   if (alertTypeParamsJSON == null) {
     throw new Error('JSON alert type params object required')
@@ -60,6 +62,7 @@ async function create (baseUrl, id, args, opts) {
 
   const body = {
     alertTypeId: id,
+    name,
     interval,
     actions,
     alertTypeParams
@@ -94,7 +97,9 @@ async function get (baseUrl, id, args, opts) {
 async function update (baseUrl, id, args, opts) {
   if (id == null) throw new Error('id parameter required')
 
-  const [interval, alertTypeParamsJSON, actionsJSON] = args
+  const [name, interval, alertTypeParamsJSON, actionsJSON, throttle = null] = args
+  if (name == null) throw new Error('name parameter required')
+
   if (interval == null) throw new Error('interval parameter required')
 
   if (alertTypeParamsJSON == null) {
@@ -111,9 +116,11 @@ async function update (baseUrl, id, args, opts) {
   if (!Array.isArray(actions)) actions = [actions]
 
   const body = {
+    name,
     interval,
     actions,
-    alertTypeParams
+    alertTypeParams,
+    throttle,
   }
 
   const uri = `api/alert/${id}`


### PR DESCRIPTION
A new required attribute will merge soon for alerts called `name` (https://github.com/elastic/kibana/pull/49035). This PR modifies the scripts to support the new attribute. Also came across a missing attribute with the update alert script where `throttle` is also required, modified command to support it as well.