### PR TITLE
Change interval prop to schedule when calling the alert API

### DIFF
--- a/lib/alert-commands.js
+++ b/lib/alert-commands.js
@@ -63,7 +63,7 @@ async function create (baseUrl, id, args, opts) {
   const body = {
     alertTypeId: id,
     name,
-    interval,
+    schedule: { interval },
     actions,
     params
   }


### PR DESCRIPTION
Changing `interval` API prop to `schedule` to align with newly merged change https://github.com/elastic/kibana/pull/52873.